### PR TITLE
Added models endpoint similar to OpenAI API models endpoint

### DIFF
--- a/local_ai/apis.py
+++ b/local_ai/apis.py
@@ -751,23 +751,23 @@ async def list_models():
     model_id = folder_name_from_info if folder_name_from_info else model_hash
 
     # Construct the ModelCard, similar to how other response objects are built
-    # Ensure 'ram' from service_info is correctly passed to 'ram_gb'
-    ram_value = service_info.get("ram")
-    ram_gb_value = None
-    if isinstance(ram_value, (int, float)):
-        ram_gb_value = float(ram_value) # Assuming it's already in GB or a direct numerical value
-    elif isinstance(ram_value, str):
+    # Ensure 'ram' from service_info is correctly parsed
+    raw_ram_value = service_info.get("ram")
+    parsed_ram_value = None
+    if isinstance(raw_ram_value, (int, float)):
+        parsed_ram_value = float(raw_ram_value)
+    elif isinstance(raw_ram_value, str):
         try:
-            # Attempt to parse if it's a string like "8GB" or "8"
-            ram_gb_value = float(ram_value.lower().replace("gb", "").strip())
+            # Attempt to parse if it's a string like "8GB", "8gb", or "8"
+            parsed_ram_value = float(raw_ram_value.lower().replace("gb", "").strip())
         except ValueError:
-            logger.warning(f"/v1/models: Could not parse RAM value '{ram_value}' to float.")
+            logger.warning(f"/v1/models: Could not parse RAM value '{raw_ram_value}' to float.")
 
     model_card = ModelCard(
         id=model_id,
         root=model_id, # Consistent with OpenAI for base models
         family=service_info.get("family"), # Assumes 'family' is in service_info
-        ram_gb=ram_gb_value,    # From Task 1, passed to ram_gb
+        ram=parsed_ram_value,    # Use 'ram' field, populated with parsed value
         folder_name=folder_name_from_info  # From Task 1
     )
 

--- a/local_ai/apis.py
+++ b/local_ai/apis.py
@@ -48,7 +48,7 @@ MAX_RETRIES = 2  # Reduced retries for faster failure handling
 RETRY_DELAY = 0.5  # Reduced delay between retries
 MAX_QUEUE_SIZE = 50  # Further reduced for better memory usage
 HEALTH_CHECK_INTERVAL = 0.5  # Faster health checks
-STREAM_CHUNK_SIZE = 16384  # Increased chunk size for better throughput
+STREAM_CHUNK_SIZE = 8  # User-specified chunk size for minimal initial buffering
 
 # Utility functions
 def get_service_info() -> Dict[str, Any]:
@@ -443,6 +443,7 @@ class ServiceHandler:
                 
                 buffer = bytearray()  # Use bytearray for more efficient byte operations
                 async for chunk in response.aiter_bytes(chunk_size=STREAM_CHUNK_SIZE):
+                    logger.info(f"Raw AI service chunk: {chunk!r}")
                     buffer.extend(chunk)
                     
                     # Process complete lines

--- a/local_ai/core.py
+++ b/local_ai/core.py
@@ -189,6 +189,7 @@ class LocalAIManager:
 
             logger.info(f"metadata_file: {metadata_file}")
             folder_name = ""
+            ram_requirement = None # Initialize ram_requirement
 
             # Check if metadata file exists
             if os.path.exists(metadata_file):
@@ -197,21 +198,46 @@ class LocalAIManager:
                         metadata = json.load(f)
                         service_metadata["family"] = metadata.get("family", "")
                         folder_name = metadata.get("folder_name", "")
+                        ram_requirement = metadata.get("ram") # Get ram from metadata
                         logger.info(f"Loaded metadata from {metadata_file}")
                 except Exception as e:
                     logger.error(f"Error loading metadata file: {e}")
-                    metadata_file = None
-            else:
+                    metadata_file = None # Keep this to signify that local metadata loading failed or didn't happen
+                    # Ensure response_json is fetched if local metadata fails
+                    response_json = self._retry_request_json(f"https://gateway.lighthouse.storage/ipfs/{hash}", retries=3, delay=5, timeout=10)
+                    if response_json:
+                        folder_name = response_json.get("folder_name", "")
+                        service_metadata["family"] = response_json.get("family", "")
+                        ram_requirement = response_json.get("ram") # Get ram from response_json
+                        # Attempt to save fetched metadata
+                        try:
+                            with open(metadata_file, "w") as f_out: # use different file handler
+                                json.dump(response_json, f_out)
+                            logger.info(f"Saved fetched metadata to {metadata_file}")
+                        except Exception as e_save:
+                            logger.error(f"Error saving fetched metadata file: {e_save}")
+                    else: # Case where fetching from IPFS also fails
+                        logger.warning(f"Could not load or fetch metadata for {hash}")
+
+            else: # Metadata file does not exist, fetch from IPFS
                 filecoin_url = f"https://gateway.lighthouse.storage/ipfs/{hash}"
                 response_json = self._retry_request_json(filecoin_url, retries=3, delay=5, timeout=10)
-                folder_name = response_json.get("folder_name", "")
-                service_metadata["family"] = response_json.get("family", "")
-                try:
-                    with open(metadata_file, "w") as f:
-                        json.dump(response_json, f)
-                    logger.info(f"Saved metadata to {metadata_file}")
-                except Exception as e:
-                    logger.error(f"Error saving metadata file: {e}")
+                if response_json:
+                    folder_name = response_json.get("folder_name", "")
+                    service_metadata["family"] = response_json.get("family", "")
+                    ram_requirement = response_json.get("ram") # Get ram from response_json
+                    try:
+                        with open(metadata_file, "w") as f:
+                            json.dump(response_json, f)
+                        logger.info(f"Saved metadata to {metadata_file}")
+                    except Exception as e:
+                        logger.error(f"Error saving metadata file: {e}")
+                else: # Case where fetching from IPFS fails and no local file
+                    logger.warning(f"Could not fetch metadata for {hash} and no local file found.")
+
+            # Add folder_name and ram to service_metadata, consistent with other keys
+            service_metadata["folder_name"] = folder_name
+            service_metadata["ram"] = ram_requirement
 
             if "gemma" in folder_name.lower():
                 template_path, best_practice_path = self._get_family_template_and_practice("gemma")

--- a/local_ai/schema.py
+++ b/local_ai/schema.py
@@ -288,7 +288,7 @@ class ModelCard(BaseModel):
     parent: Optional[str] = None
     permission: List[ModelPermission] = Field(default_factory=lambda: [ModelPermission()])
     family: Optional[str] = None
-    ram_gb: Optional[float] = None # Changed from ram to ram_gb for clarity if it represents GB
+    ram: Optional[float] = None # Aligned to use 'ram' consistent with service_info
     folder_name: Optional[str] = None
 
 class ModelList(BaseModel):


### PR DESCRIPTION
1. Small fix for dynamic local-ai repo collection, to allow seemless development inside jetson.sh
2. Set small stream chunk size for better user experience:
STREAM_CHUNK_SIZE = 8
3. Added models endpoint similar to OpenAI API models endpoint:
```
$ curl http://localhost:8080/v1/models | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --100   520  100   520    0     0   132k      0 --:--:-- --:--:-- --:--:--  169k
{
  "object": "list",
  "data": [
    {
      "id": "qwen3-30b-a3b-q8",
      "object": "model",
      "created": 1750591461,
      "owned_by": "user",
      "root": "qwen3-30b-a3b-q8",
      "parent": null,
      "permission": [
        {
          "id": "modelperm-fc7b209535b8438eb52360ccea524d3d",
          "object": "model_permission",
          "created": 1750591461,
          "allow_create_engine": false,
          "allow_sampling": true,
          "allow_logprobs": true,
          "allow_search_indices": false,
          "allow_view": true,
          "allow_fine_tuning": false,
          "organization": "*",
          "group": null,
          "is_blocking": false
        }
      ],
      "family": null,
      "ram": 37.35,
      "folder_name": "qwen3-30b-a3b-q8"
    }
  ]
}
```